### PR TITLE
Add ctrl-cmd-tab to tab through projects in MRU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.0
+
+* Add `ctrl-cmd-tab` and `ctrl-shift-cmd-tab` to tab through projects (by most-recently-used)
+* Fix memory leak by tabs package (was recreating subscriptions on each deserialization)
+* Support glob patterns in folder whitelist/blacklist — [@shemerey](https://github.com/shemerey)
+* Fix folder match (for sub-folders) in whitelist/blacklist — [@shemerey](https://github.com/shemerey)
+
 ## 0.6.0
 
 * Sort projects by most-recently-used (MRU)

--- a/keymaps/project-plus.cson
+++ b/keymaps/project-plus.cson
@@ -1,17 +1,20 @@
 '.platform-darwin':
   'ctrl-cmd-p': 'project-plus:toggle-project-finder'
-  'ctrl-cmd-tab': 'project-plus:open-next-recently-used-project'
-  'ctrl-shift-cmd-tab': 'project-plus:open-previous-recently-used-project'
 
-'.platform-win32':
-  'ctrl-alt-p': 'project-plus:toggle-project-finder'
   'ctrl-cmd-tab': 'project-plus:open-next-recently-used-project'
-  'ctrl-shift-cmd-tab': 'project-plus:open-previous-recently-used-project'
+  'ctrl-cmd-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
 
-'.platform-linux':
-  'ctrl-alt-p': 'project-plus:toggle-project-finder'
-  'ctrl-cmd-tab': 'project-plus:open-next-recently-used-project'
   'ctrl-shift-cmd-tab': 'project-plus:open-previous-recently-used-project'
+  'ctrl-shift-cmd-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
+
+'.platform-win32, .platform-linux':
+  'ctrl-alt-p': 'project-plus:toggle-project-finder'
+
+  'ctrl-cmd-tab': 'project-plus:open-next-recently-used-project'
+  'ctrl-cmd-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
+
+  'ctrl-shift-cmd-tab': 'project-plus:open-previous-recently-used-project'
+  'ctrl-shift-cmd-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
 
 '.project-finder atom-text-editor[mini]':
   'shift-enter': 'project-finder:open-in-new-window'

--- a/keymaps/project-plus.cson
+++ b/keymaps/project-plus.cson
@@ -1,11 +1,17 @@
 '.platform-darwin':
   'ctrl-cmd-p': 'project-plus:toggle-project-finder'
+  'ctrl-cmd-tab': 'project-plus:open-next-recently-used-project'
+  'ctrl-shift-cmd-tab': 'project-plus:open-previous-recently-used-project'
 
 '.platform-win32':
   'ctrl-alt-p': 'project-plus:toggle-project-finder'
+  'ctrl-cmd-tab': 'project-plus:open-next-recently-used-project'
+  'ctrl-shift-cmd-tab': 'project-plus:open-previous-recently-used-project'
 
 '.platform-linux':
   'ctrl-alt-p': 'project-plus:toggle-project-finder'
+  'ctrl-cmd-tab': 'project-plus:open-next-recently-used-project'
+  'ctrl-shift-cmd-tab': 'project-plus:open-previous-recently-used-project'
 
 '.project-finder atom-text-editor[mini]':
   'shift-enter': 'project-finder:open-in-new-window'

--- a/lib/project-finder-view.coffee
+++ b/lib/project-finder-view.coffee
@@ -64,11 +64,7 @@ class ProjectPlusView extends SelectListView
   populate: ->
     @setLoading("Discovering projects\u2026")
     util.findProjects().then (items) =>
-      items = items.sort (a, b) ->
-        a.timestamp.getTime() - b.timestamp.getTime()
-
-      items = items.reverse()
-
+      items = util.sortProjects(items)
       @setItems items
 
   confirmed: (item) ->

--- a/lib/project-plus.coffee
+++ b/lib/project-plus.coffee
@@ -11,12 +11,12 @@ module.exports = ProjectPlus =
       type: 'string'
       default: ''
       title: 'Folder Blacklist'
-      description: 'Projects will never be shown for paths matching this list (including subpaths), eg `$HOME/Documents` to exclude a single folder and all its children.'
+      description: 'Projects will never be shown for paths matching this list (including subpaths), eg `~/Documents` to exclude a single folder and all its children.'
     folderWhitelist:
       type: 'string'
       default: ''
       title: 'Folder Whitelist'
-      description: 'Projects will only be shown for paths matching this list (including subpaths), eg `$HOME/Workspace` to limit to a single folder and all its children.'
+      description: 'Projects will only be shown for paths matching this list (including subpaths), eg `~/Workspace` to limit to a single folder and all its children.'
 
   activate: (state) ->
     # Events subscribed to in atom's system can be easily cleaned up
@@ -28,17 +28,15 @@ module.exports = ProjectPlus =
       "project-plus:toggle-project-finder": =>
         @getProjectFinder().toggle()
 
-      "project-plus:open-next-recently-used-project": ->
-        util.findProjects().then (items) ->
-          if items.length > 0
-            items = util.sortProjects(items)
-            util.switchToProject items[0]
+      "project-plus:open-next-recently-used-project": =>
+        @getProjectTab().next()
 
-      "project-plus:open-previous-recently-used-project": ->
-        util.findProjects().then (items) ->
-          if items.length > 0
-            items = util.sortProjects(items)
-            util.switchToProject items[items.length - 1]
+      "project-plus:open-previous-recently-used-project": =>
+        @getProjectTab().previous()
+
+      "project-plus:move-active-project-to-top-of-stack": =>
+        # Clear the tab index
+        @projectTab = null
 
   deactivate: ->
     @modalPanel.destroy()
@@ -53,3 +51,10 @@ module.exports = ProjectPlus =
       @projectFinderView = new ProjectFinderView()
 
     @projectFinderView
+
+  getProjectTab: ->
+    unless @projectTab
+      ProjectTab = require "./project-tab"
+      @projectTab = new ProjectTab()
+
+    @projectTab

--- a/lib/project-plus.coffee
+++ b/lib/project-plus.coffee
@@ -28,6 +28,18 @@ module.exports = ProjectPlus =
       "project-plus:toggle-project-finder": =>
         @getProjectFinder().toggle()
 
+      "project-plus:open-next-recently-used-project": ->
+        util.findProjects().then (items) ->
+          if items.length > 0
+            items = util.sortProjects(items)
+            util.switchToProject items[0]
+
+      "project-plus:open-previous-recently-used-project": ->
+        util.findProjects().then (items) ->
+          if items.length > 0
+            items = util.sortProjects(items)
+            util.switchToProject items[items.length - 1]
+
   deactivate: ->
     @modalPanel.destroy()
     @subscriptions.dispose()

--- a/lib/project-tab.js
+++ b/lib/project-tab.js
@@ -1,0 +1,60 @@
+"use babel";
+
+import _ from "underscore-plus";
+import util from "./util";
+
+export default
+class ProjectTab {
+  constructor() {
+    // Get the current list of projects
+    this.promise = new Promise((resolve) => {
+      util.saveCurrentState().then(() => {
+        util.findProjects({excludeCurrent: false}).then((projects) => {
+          this.projects = util.sortProjects(projects);
+
+          // We are currently at what ..
+          const currentPaths = atom.project.getPaths();
+          let currentIndex = -1;
+          for (let index = 0; index < projects.length; ++index) {
+            if (_.isEqual(projects[index].paths, currentPaths)) {
+              currentIndex = index;
+              break;
+            }
+          }
+
+          this.index = currentIndex;
+          resolve();
+        });
+      });
+    });
+  }
+
+  move(offset) {
+    // Ensure that you can't tab while we're tabbing
+    if (this.inProgress) return;
+    this.inProgress = true;
+
+    this.promise.then(() => {
+      let nextIndex = this.index + offset;
+      if (nextIndex >= this.projects.length) {
+        nextIndex = 0;
+      }
+
+      this.index = nextIndex;
+
+      // Switch
+      util.switchToProject(this.projects[this.index]).then(() => {
+        // Done
+        this.inProgress = false;
+      });
+    });
+  }
+
+  next() {
+    this.move(1);
+  }
+
+  previous() {
+    this.move(-1);
+  }
+}

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -51,6 +51,14 @@ expandConfig = () ->
       return reject(err) if err
       resolve(result)
 
+# Sort projects
+exports.sortProjects = (items) ->
+  items = items.sort (a, b) ->
+    a.timestamp.getTime() - b.timestamp.getTime()
+
+  items = items.reverse()
+  items
+
 # Filter all projects
 filterProjects = (rows) ->
   return new Promise (resolve, reject) ->

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -48,7 +48,11 @@ exports.sortProjects = (items) ->
   items
 
 # Filter all projects
-filterProjects = (rows) ->
+filterProjects = (rows, options={}) ->
+  _.defaults options, {
+    excludeCurrent: true,
+  }
+
   rows = _.filter rows, (row) ->
     # Is `.project` non-null
     row.project? and
@@ -57,8 +61,9 @@ filterProjects = (rows) ->
     # Does `.project.paths` contain an array (only) of strings
     # NOTE: This one is weird -- how could the state get so corrupted?
     _.all(row.project.paths.map((pn) -> (pn || "").length > 0)) and
-    # NOTE: This hides the current project -- not sure if best idea
-    not _.isEqual(row.project.paths, atom.project.getPaths())
+    # Exclude the current project if requested
+    not options.excludeCurrent or not _.isEqual(
+      row.project.paths, atom.project.getPaths())
 
   rows = rows.map (row) ->
     # NOTE: Currently the name of the project
@@ -90,7 +95,7 @@ filterProjects = (rows) ->
 exports.filterProjects = filterProjects
 
 # Discover all available projects
-exports.findProjects = () ->
+exports.findProjects = (options) ->
   return new Promise (resolve, reject) ->
     if atom.stateStore?
       # Atom 1.7+
@@ -125,7 +130,7 @@ exports.findProjects = () ->
                 dbResolve(rows)
 
         .then (rows) ->
-          resolve(filterProjects(rows))
+          resolve(filterProjects(rows, options))
 
     else
       # Atom 1.5 to 1.6
@@ -155,7 +160,7 @@ exports.findProjects = () ->
 
         ), (err, rows) ->
           return reject(err) if err
-          resolve(filterProjects(rows))
+          resolve(filterProjects(rows, options))
 
 # shim atom.packages.serialize in <= 1.6
 packageStatesSerialize = () ->
@@ -205,32 +210,39 @@ loadState = (key) ->
     Promise.resolve atom.getStorageFolder().load(key)
 
 exports.switchToProject = (item) ->
-  # Compute new state key from paths
-  newKey = atom.getStateKey(item.paths)
+  new Promise (resolve) ->
+    # Compute new state key from paths
+    newKey = atom.getStateKey(item.paths)
 
-  # Save the state of the current project
-  saveCurrentState().then () ->
-    # Load the state of the new project
-    loadState(newKey).then (state) ->
-      atomDeserialize(state)
+    # Save the state of the current project
+    saveCurrentState().then () ->
 
-      # TODO: These are areas where we should submit PRs to
-      #       open functionality for it
+      # HACK: Tab bar doesn't unsubscribe; memory leak
+      tabs = atom.packages.getActivePackage("tabs")
+      if tabs
+        tabBarView.unsubscribe() for tabBarView in tabs.mainModule.tabBarViews
 
-      # HACK: Tree view doesn't reload expansion states
-      tvState = state.packageStates["tree-view"]
-      if tvState
-        treeViewPack = atom.packages.getActivePackage("tree-view")
-        tv = treeViewPack?.mainModule?.treeView
-        if tv
-          tv.attach() unless tv.isVisible()
-          tv.updateRoots(tvState.directoryExpansionStates)
-          tv.selectEntry(tv.roots[0])
-          tv.selectEntryForPath(tvState.selectedPath) if tvState.selectedPath
-          tv.focus() if tvState.hasFocus
-          tv.scroller.scrollLeft(tvState.scrollLeft) if tvState.scrollLeft > 0
-          tv.scrollTop(tvState.scrollTop) if tvState.scrollTop > 0
+      # Load the state of the new project
+      loadState(newKey).then (state) ->
+        atomDeserialize(state)
 
-      # HACK: Re-focus editor (if tree-view didn't have focus)
-      unless tvState.hasFocus
-        atom.workspace.getActivePane().activate()
+        # HACK: Tree view doesn't reload expansion states
+        tvState = state.packageStates["tree-view"]
+        if tvState
+          treeViewPack = atom.packages.getActivePackage("tree-view")
+          tv = treeViewPack?.mainModule?.treeView
+          if tv
+            tv.attach() unless tv.isVisible()
+            tv.updateRoots(tvState.directoryExpansionStates)
+            tv.selectEntry(tv.roots[0])
+            tv.selectEntryForPath(tvState.selectedPath) if tvState.selectedPath
+            tv.focus() if tvState.hasFocus
+            tv.scroller.scrollLeft(tvState.scrollLeft) if tvState.scrollLeft > 0
+            tv.scrollTop(tvState.scrollTop) if tvState.scrollTop > 0
+
+        # HACK: Re-focus editor (if tree-view didn't have focus)
+        unless tvState.hasFocus
+          atom.workspace.getActivePane().activate()
+
+        # Done
+        resolve()


### PR DESCRIPTION
- [x] Add `ctrl-cmd-tab` to go to next recently used project
- [x] Add `ctrl-shift-cmd-tab` to go to previous recently used project
- [x] Defer updating timestamp until the `ctrl` key is released (how `alt-tab` works in an OS)
