### PR TITLE
Add newWindow config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ apm install project-plus
 #### Project Finder
 
  - `ctrl-alt-p` (linux/windows) or `ctrl-cmd-p` (mac) to open the project finder
- - `enter` will open the project in the current window
- - `shift-enter` will open the project in a new window
+ - `enter` will open the project in the current window by default[*](#open-in-new-window)
+ - `shift-enter` will open the project in a new window by default[*](#open-in-new-window)
 
 #### Project Tab
 
@@ -38,7 +38,7 @@ apm install project-plus
 
 #### Project Plus: Open
 
-Switch to a project (in the current atom window) by selecting one or more
+Switch to a project (in the current atom window by default[*](#open-in-new-window)) by selecting one or more
 folders using an OS folder picker.
 
 #### Project Plus: Close
@@ -64,6 +64,10 @@ Specify a folder or glob pattern to limit projects that are discovered. This is 
 #### Show Project Path
 
 Disable to hide the project paths.
+
+#### Open in New Window
+
+Open projects in a new window by default. `shift-enter` will always do the inverse.
 
 ## Contributing
 

--- a/keymaps/project-plus.cson
+++ b/keymaps/project-plus.cson
@@ -17,4 +17,4 @@
   'ctrl-shift-cmd-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
 
 '.project-finder atom-text-editor[mini]':
-  'shift-enter': 'project-finder:open-in-new-window'
+  'shift-enter': 'project-finder:alt-open' #alt-enter?

--- a/lib/project-finder-view.coffee
+++ b/lib/project-finder-view.coffee
@@ -16,8 +16,10 @@ class ProjectPlusView extends SelectListView
     @addClass("project-finder")
 
     atom.commands.add @element,
-      'project-finder:open-in-new-window': =>
-        @confirmAndOpenInNewWindow()
+      'project-finder:alt-open': =>
+        if atom.config.get('project-plus.newWindow')
+          @open(null, false)
+        else @open(null, true)
 
   destroy: ->
     @cancel()
@@ -77,17 +79,15 @@ class ProjectPlusView extends SelectListView
       items = util.sortProjects(items)
       @setItems items
 
-  confirmed: (item) ->
+  confirmed: (item) -> @open(item)
+
+  open: (item, newWindow) ->
+    item ?= @getSelectedItem()
+    newWindow ?= atom.config.get('project-plus.newWindow')
     @hide()
 
-    # Switch to project in the same window
-    util.switchToProject item
-
-  confirmAndOpenInNewWindow: () ->
-    item = @getSelectedItem()
-    @hide()
-
-    # Open project in new window
-    # TODO: `newWindow: false` means reuse existing window if possible (
-    #         might want a config option here)
-    atom.open(pathsToOpen: item.paths, newWindow: false)
+    if newWindow # Open project in new window
+      atom.open(pathsToOpen: item.paths, newWindow: true)
+    else
+      # Switch to project in the same window
+      util.switchToProject item

--- a/lib/project-plus.coffee
+++ b/lib/project-plus.coffee
@@ -21,7 +21,10 @@ module.exports = ProjectPlus =
       "project-plus:open": =>
         atom.pickFolder (selectedPaths = []) =>
           if selectedPaths
-            util.switchToProject({paths: selectedPaths})
+            if atom.config.get('project-plus.newWindow')
+              atom.open(pathsToOpen: selectedPaths, newWindow: true)
+            else
+              util.switchToProject({paths: selectedPaths})
 
       "project-plus:close": =>
         util.closeProject()

--- a/package.json
+++ b/package.json
@@ -27,6 +27,12 @@
       "title": "Project Home",
       "description": "The directory where projects are assumed to be located. Projects outside of this directory will never be shown in the project finder. NOTE: This is a case-sensitive field."
     },
+    "newWindow": {
+      "type": "boolean",
+      "default": false,
+      "title": "Open in New Window",
+      "description": "Open projects in a new window by default. `shift-enter` will trigger the opposite behavior."
+    },
     "autoDiscover": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
Add the option to open projects in a new window by default. `shift-enter` will always do the inverse.

Signed-off-by: Daniel Bayley daniel.bayley@me.com
