### PR TITLE
Fix exception during package deactivation

### DIFF
--- a/lib/project-plus.js
+++ b/lib/project-plus.js
@@ -6,8 +6,6 @@ import providerManager from './provider-manager'
 
 class ProjectPlus {
   constructor () {
-    this.projectPlusView = null
-    this.modalPanel = null
     this.subscriptions = null
   }
 
@@ -73,9 +71,10 @@ class ProjectPlus {
   }
 
   deactivate () {
-    this.modalPanel.destroy()
     this.subscriptions.dispose()
-    this.projectPlusView.destroy()
+    if (!!this.projectFinderView) {
+      this.projectFinderView.destroy();
+    }
   }
 
   serialize () {}


### PR DESCRIPTION
Project Plus was throwing an exception during package deactivation. In themain module's `deactivate()` function, it tried to call `this.modalPanel.destroy()` and `this.projectPlusView.destroy()`. However, it doesn't appear that those attributes are ever set to a non-null value, so calling `destroy()` on a null value would throw an exception.

This was easy to miss because Atom would usually ignore it (since it was either killing project plus, and didn't care if it had errors, or Atom was shutting down, and didn't care if it had errors), and didn't really cause any adverse behavior, other than some error messages in the console. Nonetheless, it's probably best to not throw unhandled exceptions.

This commit fixes the `deactivate()` function to no longer call `this.modalPanel.destroy()` or `this.projectPlusView.destroy()`. Instead, `deactivate()` checks to see if `this.projectFinderView` exists and, if so, destroys that view. 

Additionally, the initialization of  `this.modalPanel` and `this.projectPlusView` to `null` has been removed from `activate()`, since those attributes don't appear to be used any longer, and keeping them around is just confusing.
