### PR TITLE
Show git info and icon in finder view

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ Any saved projects that aren't in your project home will still be displayed.
 
 Disable to hide the project paths.
 
+#### Show Icon
+
+Enable to show an icon next to each project. You can customize the icon for each
+project in `projects.cson` (in the Atom configuration directory) with any icon from the
+[Atom Styleguide](http://flight-manual.atom.io/hacking-atom/sections/iconography/).
+
+#### Show Git Branch
+
+Show each project's current checked-out git branch next to its name in the Project
+Finder. If you have more than one path in a project, Project Plus will show the
+first path's branch.
+
+#### Show Git Modified Status
+
+Show each project's current git modified status next to its name in the Project
+Finder. If you have more than one path in a project, Project Plus will show the
+first path's status.
+
 #### Open in New Window
 
 Open projects in a new window by default. `shift-enter` will always do the inverse.

--- a/lib/model/project.js
+++ b/lib/model/project.js
@@ -1,0 +1,52 @@
+'use babel'
+
+import git from 'git-utils'
+import { getProjectTitle, getIcon } from '../util'
+
+class Project {
+
+  constructor ({ paths, provider, timestamp, title, icon }) {
+    this.paths = paths
+    this.provider = provider
+    this.timestamp = timestamp
+    this.icon = getIcon(icon || 'repo')
+    this.title = title || getProjectTitle(this)
+    this.dirty = null
+    this.branch = null
+
+    this.readGitInfo()
+  }
+
+  hasGitInfo () {
+    return (this.dirty != null) && (this.branch != null)
+  }
+
+  readGitInfo () {
+    return new Promise((resolve, reject) => {
+      // If there is more than one path, git information will be shown for the
+      // first. Either we disable multi-path git info, or make it a config.
+      const repository = git.open(this.paths[0])
+
+      if (repository) {
+        const branch = repository.getShortHead()
+        const dirty = Object.keys(repository.getStatus()).length !== 0
+        const info = {branch, dirty}
+
+        this.setGitInfo(info)
+        repository.release()
+
+        resolve(info)
+      } else {
+        resolve()
+      }
+    })
+  }
+
+  setGitInfo ({branch, dirty}) {
+    this.branch = branch
+    this.dirty = dirty
+  }
+
+}
+
+export default Project

--- a/lib/project-finder-view.js
+++ b/lib/project-finder-view.js
@@ -17,7 +17,7 @@ class ProjectPlusView extends SelectListView {
   initialize () {
     super.initialize()
 
-    this.addClass('project-finder')
+    this.addClass('project-plus')
 
     atom.commands.add(this.element, {
       'project-finder:alt-open': () => {
@@ -83,28 +83,40 @@ class ProjectPlusView extends SelectListView {
   }
 
   viewForItem (item) {
-    let showPath = atom.config.get('project-plus.showPath')
+    const showPath = atom.config.get('project-plus.showPath')
+    const showIcon = atom.config.get('project-plus.showIcon') && item.icon
+    const showBranch = atom.config.get('project-plus.showBranch')
+    const showModified = atom.config.get('project-plus.showModified')
 
     return $$(function () {
-      if (showPath) {
-        this.li({class: 'two-lines'}, () => {
-          this.div({class: 'primary-line'}, () => {
-            this.text(item.title)
-          })
+      this.li({class: showPath ? 'two-lines' : 'one-line'}, () => {
+        // Git status.
+        if (showModified && item.dirty) {
+          this.span({class: 'status status-modified icon icon-diff-modified'})
+        }
 
-          for (const pathname of item.paths) {
-            this.div({class: 'secondary-line'}, () => {
-              this.text(tildify(pathname))
-            })
+        // Primary Line.
+        const primaryIconClass = showIcon ? `icon ${item.icon}` : ''
+        this.div({class: `primary-line ${primaryIconClass}`}, () => {
+          this.span(item.title)
+
+          if (showBranch && item.branch) {
+            this.span({class: 'branch'}, item.branch)
           }
         })
-      } else {
-        this.li({class: 'one-line'}, () => {
-          this.div({class: 'primary-line'}, () => {
-            this.text(item.title)
+
+        // Secondary Line.
+        if (showPath) {
+          const secondaryIconClass = showIcon ? 'no-icon' : ''
+          this.div({class: `secondary-line ${secondaryIconClass}`}, () => {
+            for (const pathname of item.paths) {
+              this.div({class: 'secondary-line'}, () => {
+                this.text(tildify(pathname))
+              })
+            }
           })
-        })
-      }
+        }
+      })
     })
   }
 

--- a/lib/project-plus.js
+++ b/lib/project-plus.js
@@ -72,8 +72,8 @@ class ProjectPlus {
 
   deactivate () {
     this.subscriptions.dispose()
-    if (!!this.projectFinderView) {
-      this.projectFinderView.destroy();
+    if (this.projectFinderView) {
+      this.projectFinderView.destroy()
     }
   }
 

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -3,6 +3,7 @@
 import _ from 'underscore-plus'
 import notificationManager from './notification-manager'
 import * as util from './util'
+import Project from './model/project'
 
 class ProviderManager {
   constructor () {
@@ -39,24 +40,24 @@ class ProviderManager {
 
   // Find all projects; regardless of package configuration (filter, etc.)
   all (options = {}) {
-    return new Promise((resolve) => {
-      this.invoke('all').then((items) => {
-        // De-duplicate by merging together all duplicate items
-        // This has the lovely bonus of adding timestamps to
-        // projects.cson - provided projects
-        let result = {}
-        for (let item of items) {
-          let key = atom.getStateKey(item.paths)
-          result[key] = _.extend(result[key] || {}, item)
-        }
+    return this.invoke('all').then(items => {
+      // De-duplicate by merging together all duplicate items
+      // This has the lovely bonus of adding timestamps to
+      // `projects.cson` provided projects
+      let result = {}
+      for (let item of items) {
+        let key = atom.getStateKey(item.paths)
+        result[key] = _.extend(result[key] || {}, item)
+      }
 
-        result = _.values(result)
+      result = _.values(result)
 
-        // Filter
-        result = util.filterProjects(result, options)
-
-        resolve(result)
+      let projects = result.map(project => {
+        return new Project(project)
       })
+
+      // Filter
+      return util.filterProjects(projects, options)
     })
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -68,11 +68,6 @@ export function filterProjects (rows, options = {}) {
     return true
   })
 
-  // Name!
-  for (const row of rows) {
-    row.title = row.title || getProjectTitle(row)
-  }
-
   // Resolve Project Home
   const projectHomes = getProjectHomes()
 
@@ -113,3 +108,8 @@ function projectChangeNotification (item) {
 export function closeProject () {
   return atomProjectUtil.close()
 }
+
+export function getIcon (type) {
+  return type ? `icon-${type}` : null
+}
+

--- a/package.json
+++ b/package.json
@@ -21,6 +21,24 @@
       "title": "Show Project Path",
       "description": "Show project folder paths under the name of each project."
     },
+    "showIcon": {
+      "type": "boolean",
+      "default": false,
+      "title": "Show Icon",
+      "description": "Show icon next to the name of each project."
+    },
+    "showBranch": {
+      "type": "boolean",
+      "default": false,
+      "title": "Show Git Branch",
+      "description": "Show git branch next to the name of each project."
+    },
+    "showModified": {
+      "type": "boolean",
+      "default": false,
+      "title": "Show Git Modified Status",
+      "description": "Show git status next to the name of each project."
+    },
     "projectHome": {
       "type": "string",
       "default": " ",
@@ -52,6 +70,7 @@
     "atom-space-pen-views": "^2.2.0",
     "fs-plus": "^2.8.2",
     "fuzzaldrin-plus": "^0.3.1",
+    "git-utils": "~4.1.2",
     "minimatch": "^3.0.0",
     "season": "^5.3.0",
     "tildify": "^1.1.2",

--- a/spec/util-spec.js
+++ b/spec/util-spec.js
@@ -63,3 +63,14 @@ describe('filterProjects', () => {
     expect(util.filterProjects(items).length).toEqual(1)
   })
 })
+
+describe('getIcon', () => {
+  it('should return an icon class', () => {
+    expect(util.getIcon('repo')).toEqual('icon-repo')
+  })
+
+  it('should return null if no icon type is given', () => {
+    expect(util.getIcon()).toEqual(null)
+  })
+})
+

--- a/styles/project-plus.less
+++ b/styles/project-plus.less
@@ -1,8 +1,12 @@
-// The ui-variables file is provided by base themes provided by Atom.
-//
-// See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
-// for a full listing of what's available.
 @import "ui-variables";
 
 .project-plus {
+  .status {
+    float: right;
+  }
+
+  .branch, .more-paths {
+    margin-left: 5px;
+    opacity: 0.5;
+  }
 }


### PR DESCRIPTION
Relates to #32 (partly #31).
## Project Icons

Adds an icon to the left of each project view, configurable in `projects.cson` with any icon from the Atom Styleguide. It's off by default, and the default icon is `repo`, but the default could possibly be changed depending on the provider etc.
## Git Information

Displays the current git branch and modified status in each project view, both off by default. For multiple paths, only the first repo's information is shown. Not sure how else to deal with that!
## 

Pulled what I needed from atom-git-projects as directed by @prrrnd in #31 (thanks!). My only concern is the performance of reading the git repositories on each Finder View open. atom-git-projects does seem to have some project list caching, perhaps we could look into that if it's an issue!
