### PR TITLE
Fuzzy-filter projects by both title and paths

### DIFF
--- a/lib/project-finder-view.js
+++ b/lib/project-finder-view.js
@@ -5,8 +5,6 @@ import * as util from './util'
 import tildify from 'tildify'
 import providerManager from './provider-manager'
 
-let fuzzyFilter = null
-
 export default
 class ProjectPlusView extends SelectListView {
   constructor () {
@@ -124,8 +122,7 @@ class ProjectPlusView extends SelectListView {
     let filterQuery = this.getFilterQuery()
     let filteredItems = this.items
     if (filterQuery.length) {
-      if (!fuzzyFilter) fuzzyFilter = require('fuzzaldrin-plus').filter
-      filteredItems = fuzzyFilter(this.items, filterQuery, {key: this.getFilterKey()})
+      filteredItems = util.fuzzyFilterItems(filteredItems, filterQuery)
     }
 
     this.list.empty()

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,7 @@ import _ from 'underscore-plus'
 import path from 'path'
 import minimatch from 'minimatch'
 import untildify from 'untildify'
+import fuzzaldrin from 'fuzzaldrin-plus'
 import notificationManager from './notification-manager'
 import atomProjectUtil from 'atom-project-util'
 
@@ -112,4 +113,24 @@ function projectChangeNotification (item) {
 
 export function closeProject () {
   return atomProjectUtil.close()
+}
+
+export function fuzzyFilterItems (items, query) {
+  const filterKeys = [
+    {field: 'title', weight: 4},
+    {field: 'paths', weight: 1}
+  ]
+
+  for (const item of items) {
+    let score = 0
+    for (const { field, weight } of filterKeys) {
+      const candidate = Array.isArray(item[field]) ? item[field].join(':') : item[field]
+      score += fuzzaldrin.score(candidate, query) * weight
+    }
+    item.score = score
+  }
+
+  return items
+    .filter(item => item.score)
+    .sort((a, b) => b.score - a.score)
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eslint": "^2.7.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
-    "eslint-plugin-standard": "^1.3.2"
+    "eslint-plugin-standard": "^1.3.2",
+    "sinon": "~1.17.6"
   }
 }


### PR DESCRIPTION
Fixes #65. Because fuzzaldrin doesn't support multi-key filtering yet, I've implemented a custom filtering loop configured with an array of keys and their appropriate weighting. I chose a ratio of 4:1 for title:paths scoring mostly arbitrarily, but it might just be one of those things that needs tweaking to get it perfect.
