### PR TITLE
Fix errors that occur when project-tabbing

### DIFF
--- a/lib/project-tab.js
+++ b/lib/project-tab.js
@@ -42,6 +42,8 @@ class ProjectTab {
       let nextIndex = this.index + offset
       if (nextIndex >= this.projects.length) {
         nextIndex = 0
+      } else if (nextIndex < 0) {
+        nextIndex = this.projects.length - 1
       }
 
       this.index = nextIndex

--- a/lib/util.js
+++ b/lib/util.js
@@ -94,7 +94,7 @@ export function filterProjects (rows, options = {}) {
 }
 
 export function switchToProject (item) {
-  atomProjectUtil.switch(item.paths)
+  return atomProjectUtil.switch(item.paths)
     .then(() => projectChangeNotification(item))
     .catch(err => { throw err })
 }


### PR DESCRIPTION
The first is most likely a regression from the ES6 conversion (the switch util not returning the promise). The second occurs when you try to tab to the previous project in the stack.
