### PR TITLE
Change keybindings for Windows & Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ apm install project-plus
 
 #### Project Finder
 
- - `ctrl-alt-p` (linux/windows) or `ctrl-cmd-p` (mac) to open the project finder
+ - `alt-shift-p` (linux/windows) or `ctrl-cmd-p` (mac) to open the project finder
  - `enter` will open the project in the current window by default[*](#open-in-new-window)
  - `shift-enter` will open the project in a new window by default[*](#open-in-new-window)
 
 #### Project Tab
 
- - `ctrl-cmd-tab` will switch to the next recently used project
- - `ctrl-shift-cmd-tab` will switch to the previous recently used project
+ - `alt-shift-tab` (linux/windows) or `ctrl-cmd-tab` (mac) will switch to the next recently used project
+ - `ctrl-alt-shift-tab` (linux/windows) or `shift-ctrl-cmd-tab` (mac) will switch to the previous recently used project
 
 ## Commands
 

--- a/keymaps/project-plus.cson
+++ b/keymaps/project-plus.cson
@@ -8,13 +8,13 @@
   'ctrl-shift-cmd-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
 
 '.platform-win32, .platform-linux':
-  'ctrl-alt-p': 'project-plus:toggle-project-finder'
+  'alt-shift-p': 'project-plus:toggle-project-finder'
 
-  'ctrl-cmd-tab': 'project-plus:open-next-recently-used-project'
-  'ctrl-cmd-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
+  'alt-shift-tab': 'project-plus:open-next-recently-used-project'
+  'alt-shift-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
 
-  'ctrl-shift-cmd-tab': 'project-plus:open-previous-recently-used-project'
-  'ctrl-shift-cmd-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
+  'ctrl-alt-shift-tab': 'project-plus:open-previous-recently-used-project'
+  'ctrl-alt-shift-tab ^ctrl': 'project-plus:move-active-project-to-top-of-stack'
 
 '.project-finder atom-text-editor[mini]':
   'shift-enter': 'project-finder:alt-open' #alt-enter?


### PR DESCRIPTION
Windows & Linux keybindings were conflicting with the core keybinding for running package specs. I've updated those keybindings to be `alt-shift-p` and `alt-shift-tab` etc. This brings it inline with `atom-project-manager` too. Fixes #66 and #68.
