### PR TITLE
Display an error when session state retrieval fails

### DIFF
--- a/lib/notification-manager.js
+++ b/lib/notification-manager.js
@@ -7,6 +7,10 @@ class NotificationManager {
 
     atom.notifications.addSuccess(message, options)
   }
+
+  error (message, options = {}) {
+    atom.notifications.addError(message, options)
+  }
 }
 
 export default new NotificationManager()

--- a/lib/project-finder-view.js
+++ b/lib/project-finder-view.js
@@ -4,6 +4,7 @@ import {$, $$, SelectListView} from 'atom-space-pen-views'
 import * as util from './util'
 import tildify from 'tildify'
 import providerManager from './provider-manager'
+import notificationManager from './notification-manager'
 
 let fuzzyFilter = null
 
@@ -111,10 +112,21 @@ class ProjectPlusView extends SelectListView {
   // Find all projects using the indexeddb backed state
   populate () {
     this.setLoading('Discovering projects\u2026')
-    providerManager.all().then(items => {
-      items = util.sortProjects(items)
-      this.setItems(items)
-    })
+    providerManager.all()
+      .then(items => {
+        items = util.sortProjects(items)
+        this.setItems(items)
+      })
+      .catch(err => {
+        console.error('Project Plus: Could not list projects:', err.stack)
+        this.toggle()
+        notificationManager.error('Project Plus: Could not list projects', {
+          dismissable: true,
+          stack: err.stack,
+          description: 'Open the Dev Tools for more information, or file an issue ' +
+            'on [Github](https://github.com/mehcode/atom-project-plus/issues/new).'
+        })
+      })
   }
 
   // Copy code from SelectListView so we can change to fuzzaldrin-plus

--- a/lib/provider-manager.js
+++ b/lib/provider-manager.js
@@ -39,24 +39,22 @@ class ProviderManager {
 
   // Find all projects; regardless of package configuration (filter, etc.)
   all (options = {}) {
-    return new Promise((resolve) => {
-      this.invoke('all').then((items) => {
-        // De-duplicate by merging together all duplicate items
-        // This has the lovely bonus of adding timestamps to
-        // projects.cson - provided projects
-        let result = {}
-        for (let item of items) {
-          let key = atom.getStateKey(item.paths)
-          result[key] = _.extend(result[key] || {}, item)
-        }
+    return this.invoke('all').then((items) => {
+      // De-duplicate by merging together all duplicate items
+      // This has the lovely bonus of adding timestamps to
+      // projects.cson - provided projects
+      let result = {}
+      for (let item of items) {
+        let key = atom.getStateKey(item.paths)
+        result[key] = _.extend(result[key] || {}, item)
+      }
 
-        result = _.values(result)
+      result = _.values(result)
 
-        // Filter
-        result = util.filterProjects(result, options)
+      // Filter
+      result = util.filterProjects(result, options)
 
-        resolve(result)
-      })
+      return result
     })
   }
 

--- a/lib/provider/session.js
+++ b/lib/provider/session.js
@@ -18,41 +18,45 @@ function findFromIndexedDB () {
     // Atom 1.7+
     // We have state serialized to IndexedDB
     atom.stateStore.dbPromise.then((db) => {
-      const store = db.transaction(['states']).objectStore('states')
-      const request = store.openCursor()
-      let rows = []
+      try {
+        const store = db.transaction(['states']).objectStore('states')
+        const request = store.openCursor()
+        let rows = []
 
-      request.onerror = (event) => reject(event)
-      request.onsuccess = (event) => {
-        const cursor = event.target.result
-        if (cursor) {
-          rows.push(cursor.value)
-          cursor.continue()
-        } else {
-          // Map to ensure we have 100% JSON
-          rows = rows.map((row) => {
-            // Either actual JSON is stored or a JSON serialization
-            let result = row.value
-            if (typeof result === 'string' && row.isJSON) {
-              result = JSON.parse(row.value)
-            }
+        request.onerror = (event) => reject(event)
+        request.onsuccess = (event) => {
+          const cursor = event.target.result
+          if (cursor) {
+            rows.push(cursor.value)
+            cursor.continue()
+          } else {
+            // Map to ensure we have 100% JSON
+            rows = rows.map((row) => {
+              // Either actual JSON is stored or a JSON serialization
+              let result = row.value
+              if (typeof result === 'string' && row.isJSON) {
+                result = JSON.parse(row.value)
+              }
 
-            result.updatedAt = new Date(Date.parse(row.storedAt))
-            return result
-          }).filter((row) => {
-            // Filter to ensure we have a project object
-            return row.project != null
-          }).map((row) => {
-            // Convert to the common format
-            return {
-              paths: row.project.paths,
-              timestamp: row.updatedAt,
-              provider: 'session'
-            }
-          })
+              result.updatedAt = new Date(Date.parse(row.storedAt))
+              return result
+            }).filter((row) => {
+              // Filter to ensure we have a project object
+              return row.project != null
+            }).map((row) => {
+              // Convert to the common format
+              return {
+                paths: row.project.paths,
+                timestamp: row.updatedAt,
+                provider: 'session'
+              }
+            })
 
-          resolve(rows)
+            resolve(rows)
+          }
         }
+      } catch (err) {
+        return reject(err)
       }
     })
   })


### PR DESCRIPTION
While this won't actually "fix" the issue a lot of people encounter with their Atom state being corrupted, if something goes wrong it's probably nicer for the user to see the error and not the 'Discovering Projects' dialog forever. Any rejected promises or errors when trying to use the IndexedDB object are now caught, displayed to the user, and logged to the console.

Related: #67 
