### PR TITLE
Create menu for basic functions.

### DIFF
--- a/menus/project-plus.cson
+++ b/menus/project-plus.cson
@@ -2,7 +2,7 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'Bracket Matcher'
+      'label': 'Project Plus'
       'submenu': [
         { 'label': 'Open Project', 'command': 'project-plus:open' }
         { 'label': 'Close Project', 'command': 'project-plus:close' }

--- a/menus/project-plus.cson
+++ b/menus/project-plus.cson
@@ -4,6 +4,7 @@
     'submenu': [
       'label': 'Project Plus'
       'submenu': [
+        { 'label': 'Open Project Finder', 'command': 'project-plus:toggle-project-finder'}
         { 'label': 'Open Project', 'command': 'project-plus:open' }
         { 'label': 'Close Project', 'command': 'project-plus:close' }
         { 'label': 'Save Project', 'command': 'project-plus:save' }

--- a/menus/project-plus.cson
+++ b/menus/project-plus.cson
@@ -1,0 +1,15 @@
+'menu': [
+  {
+    'label': 'Packages'
+    'submenu': [
+      'label': 'Bracket Matcher'
+      'submenu': [
+        { 'label': 'Open Project', 'command': 'project-plus:open' }
+        { 'label': 'Close Project', 'command': 'project-plus:close' }
+        { 'label': 'Save Project', 'command': 'project-plus:save' }
+        { 'label': 'Remove Project', 'command': 'project-plus:remove' }
+        { 'label': 'Edit Projects', 'command': 'project-plus:edit-projects' }
+      ]
+    ]
+  }
+]


### PR DESCRIPTION
Adds a Packages -> Project Plus menu, with the following items:
'Open Project Finder'
'Open Project'
'Close Project'
'Save Project'
'Remove Project'
'Edit Projects'

These are the items that made sense to me to include, but I'd be happy to add or remove items from this menu depending on others' opinions.