### PR TITLE
Fix change on pulsar platform

### DIFF
--- a/lib/provider/session.js
+++ b/lib/provider/session.js
@@ -17,7 +17,8 @@ function findFromIndexedDB () {
 
     // Atom 1.7+
     // We have state serialized to IndexedDB
-    atom.stateStore.dbPromise.then((db) => {
+    // Since pulsar 1.122 the stateStore for IndexedDB is in indexed property
+    atom.stateStore.indexed.dbPromise.then((db) => {
       try {
         const store = db.transaction(['states']).objectStore('states')
         const request = store.openCursor()
@@ -133,7 +134,7 @@ export default class SessionProvider {
 
   remove (paths) {
     return new Promise((resolve, reject) => {
-      atom.stateStore.dbPromise.then((db) => {
+      atom.stateStore.indexed.dbPromise.then((db) => {
         const store = db
           .transaction(['states'], 'readwrite')
           .objectStore('states')


### PR DESCRIPTION
Recently the plugin stopped working on pulsar editor (atom fork).

I did some digging and it turns out that the `atom.stateStore.dbPromise` moved to `atom.stateStore.indexed.dbPromise`.

This simple fix made everything work again but it looks like the `indexed.dbPromise` might not exist in pulsar in a near future. [More details here](https://github.com/pulsar-edit/pulsar/issues/531)

This change will break people using old atom builds so if the plugin is supposed to work on both editors just let me know so I can try to work around that.